### PR TITLE
impulse: Use display_state.h to drop necessity of state notifier

### DIFF
--- a/drivers/cpufreq/cpufreq_impulse.c
+++ b/drivers/cpufreq/cpufreq_impulse.c
@@ -22,10 +22,8 @@
 #include <linux/workqueue.h>
 #include <linux/kthread.h>
 #include <linux/slab.h>
+#include <linux/display_state.h>
 #include <asm/cputime.h>
-#ifdef CONFIG_STATE_NOTIFIER
-#include <linux/state_notifier.h>
-#endif
 
 struct cpufreq_impulse_policyinfo {
 	struct timer_list policy_timer;
@@ -71,10 +69,12 @@ static struct mutex gov_lock;
 static unsigned int default_target_loads[] = {DEFAULT_TARGET_LOAD};
 
 #define DEFAULT_TIMER_RATE (20 * USEC_PER_MSEC)
-#define DEFAULT_TIMER_RATE_SUSP ((unsigned long)(50 * USEC_PER_MSEC))
+#define SCREEN_OFF_TIMER_RATE ((unsigned long)(60 * USEC_PER_MSEC))
 #define DEFAULT_ABOVE_HISPEED_DELAY DEFAULT_TIMER_RATE
 static unsigned int default_above_hispeed_delay[] = {
 	DEFAULT_ABOVE_HISPEED_DELAY };
+
+static bool display_on;
 
 struct cpufreq_impulse_tunables {
 	int usage_count;
@@ -98,9 +98,7 @@ struct cpufreq_impulse_tunables {
 	 * The sample rate of the timer used to increase frequency
 	 */
 	unsigned long timer_rate;
-#ifdef CONFIG_STATE_NOTIFIER
-	unsigned long timer_rate_prev;
-#endif
+	unsigned long prev_timer_rate;
 	/*
 	 * Wait this long before raising speed above hispeed, by default a
 	 * single timer interval.
@@ -403,6 +401,8 @@ static void cpufreq_impulse_timer(unsigned long data)
 	int i, fcpu;
 	struct cpufreq_govinfo govinfo;
 
+	display_on = is_display_on();
+
 	if (!down_read_trylock(&ppol->enable_sem))
 		return;
 	if (!ppol->governor_enabled)
@@ -416,18 +416,16 @@ static void cpufreq_impulse_timer(unsigned long data)
 	spin_lock_irqsave(&ppol->load_lock, flags);
 	ppol->last_evaluated_jiffy = get_jiffies_64();
 
-#ifdef CONFIG_STATE_NOTIFIER
-	if (!state_suspended &&
-		tunables->timer_rate != tunables->timer_rate_prev)
-		tunables->timer_rate = tunables->timer_rate_prev;
-	else if (state_suspended &&
-		tunables->timer_rate != DEFAULT_TIMER_RATE_SUSP) {
-		tunables->timer_rate_prev = tunables->timer_rate;
+	if (display_on
+		&& tunables->timer_rate != tunables->prev_timer_rate)
+		tunables->timer_rate = tunables->prev_timer_rate;
+	else if (!display_on
+		&& tunables->timer_rate != SCREEN_OFF_TIMER_RATE) {
+		tunables->prev_timer_rate = tunables->timer_rate;
 		tunables->timer_rate
 			= max(tunables->timer_rate,
-				DEFAULT_TIMER_RATE_SUSP);
+				SCREEN_OFF_TIMER_RATE);
 	}
-#endif
 
 	max_cpu = cpumask_first(ppol->policy->cpus);
 	for_each_cpu(i, ppol->policy->cpus) {
@@ -468,9 +466,7 @@ static void cpufreq_impulse_timer(unsigned long data)
 	spin_lock_irqsave(&ppol->target_freq_lock, flags);
 	cpu_load = loadadjfreq / ppol->policy->cur;
 	tunables->boosted = cpu_load >= tunables->go_hispeed_load;
-#ifdef CONFIG_STATE_NOTIFIER
-	tunables->boosted = tunables->boosted && !state_suspended;
-#endif
+	tunables->boosted = tunables->boosted && display_on;
 	this_hispeed_freq = max(tunables->hispeed_freq, ppol->policy->min);
 
 	if (tunables->boosted) {
@@ -606,11 +602,7 @@ static int cpufreq_impulse_speedchange_task(void *data)
 
  			if (ppol->target_freq != ppol->policy->cur) {
 				tunables = ppol->policy->governor_data;
-#ifdef CONFIG_STATE_NOTIFIER
-				if (tunables->powersave_bias || state_suspended)
-#else
-				if (tunables->powersave_bias)
-#endif
+				if (tunables->powersave_bias || !display_on)
 					__cpufreq_driver_target(ppol->policy,
 								ppol->target_freq,
 								CPUFREQ_RELATION_C);
@@ -898,9 +890,7 @@ static ssize_t store_timer_rate(struct cpufreq_impulse_tunables *tunables,
 		pr_warn("timer_rate not aligned to jiffy. Rounded up to %lu\n",
 			val_round);
 	tunables->timer_rate = val_round;
-#ifdef CONFIG_STATE_NOTIFIER
-	tunables->timer_rate_prev = val_round;
-#endif
+	tunables->prev_timer_rate = val_round;
 
 	return count;
 }
@@ -1107,9 +1097,7 @@ static struct cpufreq_impulse_tunables *alloc_tunable(
 	tunables->ntarget_loads = ARRAY_SIZE(default_target_loads);
 	tunables->min_sample_time = DEFAULT_MIN_SAMPLE_TIME;
 	tunables->timer_rate = DEFAULT_TIMER_RATE;
-#ifdef CONFIG_STATE_NOTIFIER
-	tunables->timer_rate_prev = DEFAULT_TIMER_RATE;
-#endif
+	tunables->prev_timer_rate = DEFAULT_TIMER_RATE;
 	tunables->timer_slack_val = DEFAULT_TIMER_SLACK;
 
 	spin_lock_init(&tunables->target_loads_lock);


### PR DESCRIPTION
Ehhhh the PR wasn't intentional, kinda went on autopilot and forgot editing a file makes it want to submit a PR. Was gonna send the patch your way anyway, but oops.